### PR TITLE
Locate `pipx` executable for homelab package installation in Ansible

### DIFF
--- a/ansible/roles/apps_common/tasks/main.yml
+++ b/ansible/roles/apps_common/tasks/main.yml
@@ -10,8 +10,17 @@
     register: homelab_git_repo
     ignore_errors: '{{ ansible_check_mode }}'
 
+  - ansible.builtin.include_role:
+      name: common
+      tasks_from: resolve_executable
+    vars:
+      resolve_executable_search_name: pipx
+      resolve_executable_try_path: "{{ deploy_user_home }}/.local/bin"
+      resolve_executable_set_fact: pipx_exe_path
+
   - name: "Install homelab package via pipx"
     community.general.pipx:
+      executable: "{{ pipx_exe_path }}"
       name: homelab
       source: "{{ deploy_user_home }}/homelab"
       state: present

--- a/ansible/roles/common/tasks/resolve_executable.yml
+++ b/ansible/roles/common/tasks/resolve_executable.yml
@@ -1,0 +1,8 @@
+- name: "Determine {{ resolve_executable_search_name }} executable location"
+  ansible.builtin.stat:
+    path: "{{ resolve_executable_try_path }}/{{ resolve_executable_search_name }}"
+  register: resolve_executable_stat
+
+- name: "Set {{ resolve_executable_search_name }} location fact"
+  ansible.builtin.set_fact:
+    "{{ resolve_executable_set_fact|default('resolve_executable_found_path') }}": "{{ resolve_executable_stat.stat.exists | ternary(resolve_executable_try_path + '/' + resolve_executable_search_name, resolve_executable_search_name) }}"


### PR DESCRIPTION
This partially reuses commit ef0bf394b0afdcd032b5bceb36f4ca291d143c0e.