### PR TITLE
Replace unavailable `flock -w` usage in `pg_dumpall`

### DIFF
--- a/compose/apps/backrest/scripts/pg_dumpall
+++ b/compose/apps/backrest/scripts/pg_dumpall
@@ -3,7 +3,7 @@
 set -eu
 
 exec 8<>"${TMPDIR-/tmp}/$(basename "${0}")_lock"
-flock -w 10 || { echo "Unable to acquire lock"; exit 1; }
+flock -n 8 || { echo "Unable to acquire lock"; exit 1; }
 
 docker ps --format='{{.Names}} {{.Image}}' --filter="status=running" \
     | grep 'postgres:' \


### PR DESCRIPTION
Backrest installs busybox instead of coreutils which does not support `flock -w`