### PR TITLE
Configure `rclone sync` with `--size-only` for S3 remotes

### DIFF
--- a/compose/apps/rclone/scripts/sync_external
+++ b/compose/apps/rclone/scripts/sync_external
@@ -11,6 +11,11 @@ list_remotes() {
 }
 
 rclone_sync() {
+    case "${1#"${PREFIX}"}" in
+        s3[_:]*)
+            export RCLONE_SIZE_ONLY=true
+            ;;
+    esac
     (
         set -x
         rclone sync --create-empty-src-dirs --delete-excluded --metadata "${@}"


### PR DESCRIPTION
This avoids HEAD requests for each object