### PR TITLE
Remove emulation platform from `cups`

### DIFF
--- a/compose/apps/cups/compose.yaml
+++ b/compose/apps/cups/compose.yaml
@@ -2,7 +2,6 @@ services:
   cups:
     image: ghcr.io/smkent/homelab/cups:latest
     # build: ../../images/cups
-    platform: linux/amd64
     ports:
     - 631:631
     restart: unless-stopped


### PR DESCRIPTION
Upstream now provides an `arm64` build