### PR TITLE
Split local SMTP send from email routing Postfix

### DIFF
--- a/ansible/roles/mta/tasks/main.yml
+++ b/ansible/roles/mta/tasks/main.yml
@@ -22,7 +22,7 @@
     content: |
       account default
       host localhost
-      port 25
+      port 2525
       from sys.{{ inventory_hostname }}@{{ node_domain }}
       aliases /etc/aliases
       auth off

--- a/compose/apps/postfix/compose.yaml
+++ b/compose/apps/postfix/compose.yaml
@@ -11,7 +11,7 @@ volumes:
     driver: local
 
 services:
-  smtp:
+  postfix:
     image: ghcr.io/smkent/homelab/postfix:latest
     # build: ../../images/postfix
     env_file:

--- a/compose/apps/postfix/postfix.env
+++ b/compose/apps/postfix/postfix.env
@@ -1,5 +1,5 @@
 POSTFIX_myhostname=${NODE_FQDN?}
-POSTFIX_mynetworks=127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+POSTFIX_mynetworks=127.0.0.0/8
 POSTFIX_smtpd_sasl_auth_enable=yes
 POSTFIX_smtpd_sasl_security_options=noanonymous
 POSTFIX_broken_sasl_auth_clients=yes

--- a/compose/apps/smtp_relay/compose.yaml
+++ b/compose/apps/smtp_relay/compose.yaml
@@ -17,8 +17,8 @@ services:
     networks:
     - web
     ports:
-    - "127.0.0.1:25:25"
-    - "[::1]:25:25"
+    - "127.0.0.1:2525:25"
+    - "[::1]:2525:25"
     restart: unless-stopped
     secrets:
     - smtp-submit-password

--- a/compose/hosts/io/apps.yml
+++ b/compose/hosts/io/apps.yml
@@ -13,4 +13,5 @@ apps:
 - nextcloud
 - ofelia
 - postfix
+- smtp_relay
 - web

--- a/compose/hosts/io/host.env
+++ b/compose/hosts/io/host.env
@@ -5,3 +5,6 @@ NODE_FQDN=${DOMAIN}
 LDAP_BASE_DN=dc=smkent,dc=net
 
 APP_POSTFIX_RELAY_MAP=healthchecks.${DOMAIN?},smtp:[healthchecks]:25
+
+SMTP_RELAY_HOST=${DOMAIN}
+SMTP_RELAY_PORT=587


### PR DESCRIPTION
This binds the local send SMTP server to `localhost` port 2525 to leave port 25 free for the email routing instance of Postfix